### PR TITLE
Add rust-utilities/liquid-grammar-pest#1 to readme

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -53,6 +53,7 @@ Here are some example projects using pest:
 - [Melody](https://github.com/yoav-lavi/melody) - Melody is a language that compiles to regular expressions and aims to be more easily readable and maintainable.
 - [PTA-Parser](https://github.com/AltaModaTech/pta-parser/) - A Plain Text Accounting parser built in Rust for [Beancount](https://github.com/beancount/beancount), [Ledger](https://github.com/ledger/ledger), and other PTA formats.
 - [Keadex Mina](https://github.com/keadex/keadex) - Open Source, serverless IDE to code with C4-PlantUML and organize at a scale C4 model diagrams.
+- [Liquid Grammar](https://github.com/rust-utilities/liquid-grammar-pest/) - Generate `Pairs` and/or `Rules` for [Shopify](https://shopify.github.io/liquid/) Liquid (hash-tags _not-sponsored_ or _affiliated_) for use in consuming crates
 
 ## Tooling
 


### PR DESCRIPTION
As requested by the [@tomtau](https://github.com/pest-parser/pest/discussions/1021#discussioncomment-9865757) via discussion thread showing-and-telling "Grammar for Shopify Liquid!", I am submitting a link to the related GitHub org/repo :-D

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Added "Liquid Grammar" to the list of example projects using `pest` in the readme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->